### PR TITLE
Redefine interfaces for Signalization

### DIFF
--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Cancellation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Cancellation.cs
@@ -1,0 +1,58 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="ICancellation"/>.
+    /// </summary>
+    public sealed class Cancellation :
+        ICancellation
+    {
+        private readonly Action onCancelled;
+
+        #region Constructor
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onCancelled">
+        /// <see cref="Action"/> to execute when this has cancelled.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onCancelled"/> is null.
+        /// </exception>
+        public Cancellation(Action onCancelled)
+        {
+            if (onCancelled == null)
+            {
+                throw new ArgumentNullException(nameof(onCancelled));
+            }
+
+            this.onCancelled = onCancelled;
+        }
+
+        /// <summary>
+        /// Constructs an instance to do nothing when this has cancelled.
+        /// </summary>
+        public Cancellation()
+        {
+            onCancelled = () =>
+            {
+
+            };
+        }
+
+        #endregion
+
+        #region ICancellation
+
+        /// <inheritdoc/>
+        public void Cancel()
+        {
+            onCancelled.Invoke();
+        }
+
+        #endregion
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/CancellationSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/CancellationSpecification.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Cancellation))]
+    internal class CancellationSpecification
+    {
+        [Test]
+        public void ShouldExecuteActionWhenHasCancelled()
+        {
+            var expected = false;
+            var cancellation = new Cancellation(() =>
+            {
+                expected = true;
+            });
+
+            cancellation.Cancel();
+
+            Assert.IsTrue(expected);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var cancellation = new Cancellation(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Conduction.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Conduction.cs
@@ -1,0 +1,76 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IConduction{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to conduct.
+    /// </typeparam>
+    public sealed class Conduction<TSignal> :
+        IConduction<TSignal>
+        where TSignal : ISignal
+    {
+        private readonly Propagation<TSignal> propagation = new Propagation<TSignal>();
+
+        private readonly Func<TSignal> onEmitted;
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onEmitted">
+        /// <see cref="Func{TSignal}"/> to execute when this has emitted.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onEmitted"/> is null.
+        /// </exception>
+        public Conduction(Func<TSignal> onEmitted)
+        {
+            if (onEmitted == null)
+            {
+                throw new ArgumentNullException(nameof(onEmitted));
+            }
+
+            this.onEmitted = onEmitted;
+        }
+
+        #region IProduction
+
+        /// <inheritdoc/>
+        public ICancellation Produce(IConsumption<TSignal> consumption)
+        {
+            if (consumption == null)
+            {
+                throw new ArgumentNullException(nameof(consumption));
+            }
+
+            return propagation.Produce(consumption);
+        }
+
+        #endregion
+
+        #region IEmission
+
+        /// <inheritdoc/>
+        public void Emit()
+        {
+            var emitted = onEmitted.Invoke();
+
+            propagation.Consume(emitted);
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            propagation.Dispose();
+        }
+
+        #endregion
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ConductionSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ConductionSpecification.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Conduction<>))]
+    internal class ConductionSpecification
+    {
+        private Conduction<Signal> conduction;
+        private Consumption<Signal> consumption;
+
+        private Signal expected;
+        private Signal consumed;
+
+        [SetUp]
+        public void SetUp()
+        {
+            expected = new Signal();
+            conduction = new Conduction<Signal>(() =>
+            {
+                return expected;
+            });
+
+            consumed = default;
+            consumption = new Consumption<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                consumed = signal;
+            });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            conduction.Dispose();
+        }
+
+        [Test]
+        public void ShouldSendSignalToProducedWhenHasEmitted()
+        {
+            var cancellation = conduction.Produce(consumption);
+
+            conduction.Emit();
+
+            Assert.AreEqual(expected, consumed);
+
+            cancellation.Cancel();
+        }
+
+        [Test]
+        public void ShouldNotSendSignalToNotProducedWhenHasEmitted()
+        {
+            var cancellation = conduction.Produce(consumption);
+
+            cancellation.Cancel();
+
+            conduction.Emit();
+
+            Assert.AreNotEqual(expected, consumed);
+        }
+
+        [Test]
+        public void ShouldNotSendSignalAfterHasDisposed()
+        {
+            var cancellation = conduction.Produce(consumption);
+
+            conduction.Dispose();
+
+            conduction.Emit();
+
+            Assert.AreNotEqual(expected, consumed);
+
+            cancellation.Cancel();
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var conduction = new Conduction<Signal>(null);
+            });
+        }
+
+        [Test]
+        public void CannotProduceNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var cancellation = conduction.Produce(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Consumption.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Consumption.cs
@@ -1,0 +1,62 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IConsumption{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to consume.
+    /// </typeparam>
+    public sealed class Consumption<TSignal> :
+        IConsumption<TSignal>
+        where TSignal : ISignal
+    {
+        private readonly Action<TSignal> onConsumed;
+
+        #region Constructor
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onConsumed">
+        /// <see cref="Action{TSignal}"/> to execute when this has consumed.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onConsumed"/> is null.
+        /// </exception>
+        public Consumption(Action<TSignal> onConsumed)
+        {
+            if (onConsumed == null)
+            {
+                throw new ArgumentNullException(nameof(onConsumed));
+            }
+
+            this.onConsumed = onConsumed;
+        }
+
+        /// <summary>
+        /// Constructs an instance to do nothing when this has consumed.
+        /// </summary>
+        public Consumption()
+        {
+            onConsumed = (_) =>
+            {
+
+            };
+        }
+
+        #endregion
+
+        #region IConsumption
+
+        /// <inheritdoc/>
+        public void Consume(TSignal signal)
+        {
+            onConsumed.Invoke(signal);
+        }
+
+        #endregion
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ConsumptionSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ConsumptionSpecification.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Consumption<>))]
+    internal class ConsumptionSpecification
+    {
+        [Test]
+        public void ShouldExecuteActionWhenHasConsumed()
+        {
+            var expected = false;
+            var consumption = new Consumption<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                expected = true;
+            });
+
+            consumption.Consume(new Signal());
+
+            Assert.IsTrue(expected);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var consumption = new Consumption<Signal>(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ICancellation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ICancellation.cs
@@ -1,0 +1,13 @@
+﻿namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Token to cancel.
+    /// </summary>
+    public interface ICancellation
+    {
+        /// <summary>
+        /// Cancels.
+        /// </summary>
+        void Cancel();
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IConduction.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IConduction.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Conducts <typeparamref name="TSignal"/> to each connected <see cref="IConsumption{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to conduct.
+    /// </typeparam>
+    /// <remarks>
+    /// This is <see cref="IProduction{TSignal}"/> and <see cref="IEmission"/>.
+    /// </remarks>
+    public interface IConduction<TSignal> :
+        IProduction<TSignal>,
+        IEmission,
+        IDisposable
+        where TSignal : ISignal
+    {
+
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IConsumption.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IConsumption.cs
@@ -1,0 +1,20 @@
+﻿namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Receives <typeparamref name="TSignal"/> to consume.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to receive.
+    /// </typeparam>
+    public interface IConsumption<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Consumes <typeparamref name="TSignal"/>.
+        /// </summary>
+        /// <param name="signal">
+        /// <typeparamref name="TSignal"/> to consume.
+        /// </param>
+        void Consume(TSignal signal);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IEmission.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IEmission.cs
@@ -1,0 +1,13 @@
+﻿namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Token to emit.
+    /// </summary>
+    public interface IEmission
+    {
+        /// <summary>
+        /// Emits.
+        /// </summary>
+        void Emit();
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IProduction.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IProduction.cs
@@ -1,0 +1,23 @@
+﻿namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Sends <typeparamref name="TSignal"/> to <see cref="IConsumption{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to send.
+    /// </typeparam>
+    public interface IProduction<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Produces <typeparamref name="TSignal"/> to <see cref="IConsumption{TSignal}"/>.
+        /// </summary>
+        /// <param name="consumption">
+        /// Destination to send <typeparamref name="TSignal"/>.
+        /// </param>
+        /// <returns>
+        /// <see cref="ICancellation"/> to cancel.
+        /// </returns>
+        ICancellation Produce(IConsumption<TSignal> consumption);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IPropagation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/IPropagation.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Propagates <typeparamref name="TSignal"/> to each connected <see cref="IConsumption{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to propagate.
+    /// </typeparam>
+    /// <remarks>
+    /// This is <see cref="IProduction{TSignal}"/> and <see cref="IConsumption{TSignal}"/>.
+    /// </remarks>
+    public interface IPropagation<TSignal> :
+        IProduction<TSignal>,
+        IConsumption<TSignal>,
+        IDisposable
+        where TSignal : ISignal
+    {
+
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ISignal.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/ISignal.cs
@@ -1,0 +1,10 @@
+﻿namespace YggdrAshill.Nuadha.Signalization.Experimental
+{
+    /// <summary>
+    /// Token to define signal.
+    /// </summary>
+    public interface ISignal
+    {
+
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Propagation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Propagation.cs
@@ -1,0 +1,68 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+using System.Collections.Generic;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IPropagation{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to propagate.
+    /// </typeparam>
+    public sealed class Propagation<TSignal> :
+        IPropagation<TSignal>
+        where TSignal : ISignal
+    {
+        private readonly List<IConsumption<TSignal>> consumptionList = new List<IConsumption<TSignal>>();
+
+        #region IProduction
+
+        /// <inheritdoc/>
+        public ICancellation Produce(IConsumption<TSignal> consumption)
+        {
+            if (consumption == null)
+            {
+                throw new ArgumentNullException(nameof(consumption));
+            }
+
+            if (!consumptionList.Contains(consumption))
+            {
+                consumptionList.Add(consumption);
+            }
+
+            return new Cancellation(() =>
+            {
+                if (consumptionList.Contains(consumption))
+                {
+                    consumptionList.Remove(consumption);
+                }
+            });
+        }
+
+        #endregion
+
+        #region IConsumption
+
+        /// <inheritdoc/>
+        public void Consume(TSignal signal)
+        {
+            foreach (var consumption in consumptionList)
+            {
+                consumption.Consume(signal);
+            }
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            consumptionList.Clear();
+        }
+
+        #endregion
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/PropagationSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/PropagationSpecification.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Propagation<>))]
+    internal class PropagationSpecification
+    {
+        private Propagation<Signal> propagation;
+        private Consumption<Signal> consumption;
+
+        private Signal expected;
+        private Signal consumed;
+
+        [SetUp]
+        public void SetUp()
+        {
+            propagation = new Propagation<Signal>();
+
+            consumed = default;
+            consumption = new Consumption<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                consumed = signal;
+            });
+
+            expected = new Signal();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            propagation.Dispose();
+        }
+
+        [Test]
+        public void ShouldSendSignalToProducedWhenHasConsumed()
+        {
+            var cancellation = propagation.Produce(consumption);
+
+            propagation.Consume(expected);
+
+            Assert.AreEqual(expected, consumed);
+
+            cancellation.Cancel();
+        }
+
+        [Test]
+        public void ShouldNotSendSignalToNotProducedWhenHasConsumed()
+        {
+            var cancellation = propagation.Produce(consumption);
+
+            cancellation.Cancel();
+
+            propagation.Consume(expected);
+
+            Assert.AreNotEqual(expected, consumed);
+        }
+
+        [Test]
+        public void ShouldNotSendSignalAfterHasDisposed()
+        {
+            var cancellation = propagation.Produce(consumption);
+
+            propagation.Dispose();
+
+            propagation.Consume(expected);
+
+            Assert.AreNotEqual(expected, consumed);
+
+            cancellation.Cancel();
+        }
+
+        [Test]
+        public void CannotProduceNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var cancellation = propagation.Produce(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Signal.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Signalization/Signal.cs
@@ -1,0 +1,10 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    internal sealed class Signal :
+        ISignal
+    {
+
+    }
+}


### PR DESCRIPTION
## Summary

Redefined how to send/receive signals.
Added

- Propagation
- Conduction

interfaces defined using

- Production
- Consumption
- Cancellation
- Emission

## Done

This pull request only redefined

- interfaces
- implementations
- specifications

for Signalization.

## Undone

This pull request didn't replace Signalization module.
Therefore, the namespace of new definitions for Signalization has "Experimental".

## Influence

This pull request doesn't influence this framework.
But, Signalization module needs to be replaced with new definitions eventually.

## Concerns

Nothing because this pull request was created by repository owner.

## Additional context (Optional)
Nothing.
