### PR TITLE
Define interfaces for Transformation

### DIFF
--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Conversion.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Conversion.cs
@@ -1,0 +1,48 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IConversion{TInput, TOutput}"/>.
+    /// </summary>
+    /// <typeparam name="TInput">
+    /// Type of <see cref="ISignal"/> to convert.
+    /// </typeparam>
+    /// <typeparam name="TOutput">
+    /// Type of <see cref="ISignal"/> converted.
+    /// </typeparam>
+    public sealed class Conversion<TInput, TOutput> :
+        IConversion<TInput, TOutput>
+        where TInput : ISignal
+        where TOutput : ISignal
+    {
+        private readonly Func<TInput, TOutput> onConverted;
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onConverted">
+        /// <see cref="Func{TInput, TOutput}"/> to execute when this has converted.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onConverted"/> is null.
+        /// </exception>
+        public Conversion(Func<TInput, TOutput> onConverted)
+        {
+            if (onConverted == null)
+            {
+                throw new ArgumentNullException(nameof(onConverted));
+            }
+
+            this.onConverted = onConverted;
+        }
+
+        /// <inheritdoc/>
+        public TOutput Convert(TInput signal)
+        {
+            return onConverted.Invoke(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/ConversionSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/ConversionSpecification.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Conversion<,>))]
+    internal class ConversionSpecification
+    {
+        [Test]
+        public void ShouldExecuteFunctionWhenHasConverted()
+        {
+            var expected = false;
+            var conversion = new Conversion<InputSignal, OutputSignal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                expected = true;
+
+                return new OutputSignal();
+            });
+
+            var converted = conversion.Convert(new InputSignal());
+
+            Assert.IsTrue(expected);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var conversion = new Conversion<InputSignal, OutputSignal>(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Convert.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Convert.cs
@@ -1,0 +1,28 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Convert<TInput, TOutput> :
+        IConsumption<TInput>
+        where TInput : ISignal
+        where TOutput : ISignal
+    {
+        private readonly IConversion<TInput, TOutput> conversion;
+
+        private readonly IConsumption<TOutput> consumption;
+
+        internal Convert(IConversion<TInput, TOutput> conversion, IConsumption<TOutput> consumption)
+        {
+            this.conversion = conversion;
+
+            this.consumption = consumption;
+        }
+
+        public void Consume(TInput signal)
+        {
+            var converted = conversion.Convert(signal);
+
+            consumption.Consume(converted);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Converter.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/Converter.cs
@@ -1,0 +1,32 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Converter<TInput, TOutput> :
+        IProduction<TOutput>
+        where TInput : ISignal
+        where TOutput : ISignal
+    {
+        private readonly IProduction<TInput> production;
+
+        private readonly IConversion<TInput, TOutput> conversion;
+
+        internal Converter(IProduction<TInput> production, IConversion<TInput, TOutput> conversion)
+        {
+            this.production = production;
+
+            this.conversion = conversion;
+        }
+
+        public ICancellation Produce(IConsumption<TOutput> consumption)
+        {
+            if (consumption == null)
+            {
+                throw new ArgumentNullException(nameof(consumption));
+            }
+
+            return production.Produce(new Convert<TInput, TOutput>(conversion, consumption));
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/IConversion.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Conversion/IConversion.cs
@@ -1,0 +1,29 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Converts <typeparamref name="TInput"/> to <typeparamref name="TOutput"/>.
+    /// </summary>
+    /// <typeparam name="TInput">
+    /// Type of <see cref="ISignal"/> to convert.
+    /// </typeparam>
+    /// <typeparam name="TOutput">
+    /// Type of <see cref="ISignal"/> converted.
+    /// </typeparam>
+    public interface IConversion<TInput, TOutput>
+        where TInput : ISignal
+        where TOutput : ISignal
+    {
+        /// <summary>
+        /// Converts <typeparamref name="TInput"/> to <typeparamref name="TOutput"/>.
+        /// </summary>
+        /// <param name="signal">
+        /// <typeparamref name="TInput"/> to convert.
+        /// </param>
+        /// <returns>
+        /// <typeparamref name="TOutput"/> converted.
+        /// </returns>
+        TOutput Convert(TInput signal);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/Correct.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/Correct.cs
@@ -1,0 +1,21 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Correct<TSignal> :
+        IConversion<TSignal, TSignal>
+        where TSignal : ISignal
+    {
+        private readonly ICorrection<TSignal> correction;
+
+        internal Correct(ICorrection<TSignal> correction)
+        {
+            this.correction = correction;
+        }
+
+        public TSignal Convert(TSignal signal)
+        {
+            return correction.Correct(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/Correction.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/Correction.cs
@@ -1,0 +1,55 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="ICorrection{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to correct.
+    /// </typeparam>
+    public sealed class Correction<TSignal> :
+        ICorrection<TSignal>
+        where TSignal : ISignal
+    {
+        private readonly Func<TSignal, TSignal> onCorrected;
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onCorrected">
+        /// <see cref="Func{TInput, TOutput}"/> to execute when this has corrected.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onCorrected"/> is null.
+        /// </exception>
+        public Correction(Func<TSignal, TSignal> onCorrected)
+        {
+            if (onCorrected == null)
+            {
+                throw new ArgumentNullException(nameof(onCorrected));
+            }
+
+            this.onCorrected = onCorrected;
+        }
+
+        /// <summary>
+        /// Constructs an instance to do nothing when this has corrected.
+        /// </summary>
+        public Correction()
+        {
+            onCorrected = (signal) =>
+            {
+                return signal;
+            };
+        }
+
+        /// <inheritdoc/>
+        public TSignal Correct(TSignal signal)
+        {
+            return onCorrected.Invoke(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/CorrectionSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/CorrectionSpecification.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Correction<>))]
+    internal class CorrectionSpecification
+    {
+        [Test]
+        public void ShouldExecuteFunctionWhenHasCorrected()
+        {
+            var expected = false;
+            var correction = new Correction<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                expected = true;
+
+                return signal;
+            });
+
+            var corrected = correction.Correct(new Signal());
+
+            Assert.IsTrue(expected);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var correction = new Correction<Signal>(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/ICorrection.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Correction/ICorrection.cs
@@ -1,0 +1,25 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Corrects <typeparamref name="TSignal"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to correct.
+    /// </typeparam>
+    public interface ICorrection<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Corrects <typeparamref name="TSignal"/>.
+        /// </summary>
+        /// <param name="signal">
+        /// <typeparamref name="TSignal"/> to correct.
+        /// </param>
+        /// <returns>
+        /// <typeparamref name="TSignal"/> corrected.
+        /// </returns>
+        TSignal Correct(TSignal signal);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detect.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detect.cs
@@ -1,0 +1,28 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Detect<TSignal> :
+        IConsumption<TSignal>
+        where TSignal : ISignal
+    {
+        private readonly IDetection<TSignal> detection;
+
+        private readonly IConsumption<Notice> consumption;
+
+        internal Detect(IDetection<TSignal> detection, IConsumption<Notice> consumption)
+        {
+            this.detection = detection;
+
+            this.consumption = consumption;
+        }
+
+        public void Consume(TSignal signal)
+        {
+            if (detection.Detect(signal))
+            {
+                consumption.Consume(null);
+            }
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detection.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detection.cs
@@ -1,0 +1,62 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IDetection{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to detect.
+    /// </typeparam>
+    public sealed class Detection<TSignal> :
+        IDetection<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Always detects <typeparamref name="TSignal"/>.
+        /// </summary>
+        public static Detection<TSignal> All { get; }
+            = new Detection<TSignal>(_ =>
+            {
+                return true;
+            });
+
+        /// <summary>
+        /// Never detects <typeparamref name="TSignal"/>.
+        /// </summary>
+        public static Detection<TSignal> None { get; }
+            = new Detection<TSignal>(_ =>
+            {
+                return false;
+            });
+
+        private readonly Func<TSignal, bool> onDetected;
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onDetected">
+        /// <see cref="Func{TSignal, bool}"/> to execute when this has detected.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onDetected"/> is null.
+        /// </exception>
+        public Detection(Func<TSignal, bool> onDetected)
+        {
+            if (onDetected == null)
+            {
+                throw new ArgumentNullException(nameof(onDetected));
+            }
+
+            this.onDetected = onDetected;
+        }
+
+        /// <inheritdoc/>
+        public bool Detect(TSignal signal)
+        {
+            return onDetected.Invoke(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/DetectionSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/DetectionSpecification.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+
+    [TestFixture(TestOf = typeof(Detection<>))]
+    internal class DetectionSpecification
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShouldExecuteFunctionWhenHasDetected(bool expected)
+        {
+            var detection = new Detection<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                return expected;
+            });
+
+            var detected = detection.Detect(new Signal());
+
+            Assert.AreEqual(expected, detected);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var detection = new Detection<Signal>(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detector.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Detector.cs
@@ -1,0 +1,31 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Detector<TSignal> :
+        IProduction<Notice>
+        where TSignal : ISignal
+    {
+        private readonly IProduction<TSignal> production;
+
+        private readonly IDetection<TSignal> detection;
+
+        internal Detector(IProduction<TSignal> production, IDetection<TSignal> detection)
+        {
+            this.production = production;
+
+            this.detection = detection;
+        }
+
+        public ICancellation Produce(IConsumption<Notice> consumption)
+        {
+            if (consumption == null)
+            {
+                throw new ArgumentNullException(nameof(consumption));
+            }
+
+            return production.Produce(new Detect<TSignal>(detection, consumption));
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/IDetection.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/IDetection.cs
@@ -1,0 +1,25 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Detects <typeparamref name="TSignal"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to detect.
+    /// </typeparam>
+    public interface IDetection<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Detects <typeparamref name="TSignal"/>.
+        /// </summary>
+        /// <param name="signal">
+        /// <typeparamref name="TSignal"/> to detect.
+        /// </param>
+        /// <returns>
+        /// True if <typeparamref name="TSignal"/> is detected.
+        /// </returns>
+        bool Detect(TSignal signal);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Notice.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/Notice.cs
@@ -1,0 +1,29 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="ISignal"/>.
+    /// </summary>
+    public sealed class Notice :
+        ISignal,
+        IEquatable<Notice>
+    {
+        /// <summary>
+        /// Singleton instance of <see cref="Notice"/>.
+        /// </summary>
+        public static Notice Instance { get; } = new Notice();
+
+        private Notice()
+        {
+
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(Notice other)
+        {
+            return ReferenceEquals(this, other);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/NoticeSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/NoticeSpecification.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Notice))]
+    internal class NoticeSpecification
+    {
+        [Test]
+        public void ShouldBeEqualToAnyInstance()
+        {
+            Assert.AreEqual(Notice.Instance, Notice.Instance);
+        }
+
+        [Test]
+        public void CannotBeEqualToNull()
+        {
+            Assert.AreNotEqual(Notice.Instance, null);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulse.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulse.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IDetection{TSignal}"/> for <see cref="Pulse"/>.
+    /// </summary>
+    public sealed class WhenPulse :
+        IDetection<Pulse>
+    {
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> is <see cref="Pulse.IsDisabled"/>.
+        /// </summary>
+        public static WhenPulse IsDisabled { get; } = new WhenPulse(Pulse.IsDisabled);
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> is <see cref="Pulse.HasDisabled"/>.
+        /// </summary>
+        public static WhenPulse HasDisabled { get; } = new WhenPulse(Pulse.HasDisabled);
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> is <see cref="Pulse.IsEnabled"/>.
+        /// </summary>
+        public static WhenPulse IsEnabled { get; } = new WhenPulse(Pulse.IsEnabled);
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> is <see cref="Pulse.HasEnabled"/>.
+        /// </summary>
+        public static WhenPulse HasEnabled { get; } = new WhenPulse(Pulse.HasEnabled);
+
+        private readonly Pulse expected;
+
+        private WhenPulse(Pulse expected)
+        {
+            this.expected = expected;
+        }
+
+        /// <inheritdoc/>
+        public bool Detect(Pulse signal)
+        {
+            if (signal == null)
+            {
+                throw new ArgumentNullException(nameof(signal));
+            }
+
+            return expected == signal;
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseOf.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseOf.cs
@@ -1,0 +1,108 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Implementaion of <see cref="IDetection{TSignal}"/> with <see cref="IPulsation{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to detect.
+    /// </typeparam>
+    public sealed class WhenPulseOf<TSignal> :
+        IDetection<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> converted from <typeparamref name="TSignal"/> is <see cref="Pulse.IsDisabled"/>.
+        /// </summary>
+        /// <param name="pulsation">
+        /// <see cref="IPulsation{TSignal}"/> to convert <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+        /// </param>
+        /// <returns>
+        /// <see cref="WhenPulseOf{TSignal}"/> to detect <typeparamref name="TSignal"/>.
+        /// </returns>
+        public static WhenPulseOf<TSignal> IsDisabled(IPulsation<TSignal> pulsation)
+        {
+            if (pulsation == null)
+            {
+                throw new ArgumentNullException(nameof(pulsation));
+            }
+
+            return new WhenPulseOf<TSignal>(pulsation, WhenPulse.IsDisabled);
+        }
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> converted from <typeparamref name="TSignal"/> is <see cref="Pulse.HasDisabled"/>.
+        /// </summary>
+        /// <param name="pulsation">
+        /// <see cref="IPulsation{TSignal}"/> to convert <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+        /// </param>
+        /// <returns>
+        /// <see cref="WhenPulseOf{TSignal}"/> to detect <typeparamref name="TSignal"/>.
+        /// </returns>
+        public static WhenPulseOf<TSignal> HasDisabled(IPulsation<TSignal> pulsation)
+        {
+            if (pulsation == null)
+            {
+                throw new ArgumentNullException(nameof(pulsation));
+            }
+
+            return new WhenPulseOf<TSignal>(pulsation, WhenPulse.HasDisabled);
+        }
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> converted from <typeparamref name="TSignal"/> is <see cref="Pulse.IsDisabled"/>.
+        /// </summary>
+        /// <param name="pulsation">
+        /// <see cref="IPulsation{TSignal}"/> to convert <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+        /// </param>
+        /// <returns>
+        /// <see cref="WhenPulseOf{TSignal}"/> to detect <typeparamref name="TSignal"/>.
+        /// </returns>
+        public static WhenPulseOf<TSignal> IsEnabled(IPulsation<TSignal> pulsation)
+        {
+            if (pulsation == null)
+            {
+                throw new ArgumentNullException(nameof(pulsation));
+            }
+
+            return new WhenPulseOf<TSignal>(pulsation, WhenPulse.IsEnabled);
+        }
+        /// <summary>
+        /// Detects when <see cref="Pulse"/> converted from <typeparamref name="TSignal"/> is <see cref="Pulse.IsDisabled"/>.
+        /// </summary>
+        /// <param name="pulsation">
+        /// <see cref="IPulsation{TSignal}"/> to convert <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+        /// </param>
+        /// <returns>
+        /// <see cref="WhenPulseOf{TSignal}"/> to detect <typeparamref name="TSignal"/>.
+        /// </returns>
+        public static WhenPulseOf<TSignal> HasEnabled(IPulsation<TSignal> pulsation)
+        {
+            if (pulsation == null)
+            {
+                throw new ArgumentNullException(nameof(pulsation));
+            }
+
+            return new WhenPulseOf<TSignal>(pulsation, WhenPulse.HasEnabled);
+        }
+
+        private readonly IPulsation<TSignal> pulsation;
+
+        private readonly IDetection<Pulse> detection;
+
+        private WhenPulseOf(IPulsation<TSignal> pulsation, IDetection<Pulse> detection)
+        {
+            this.pulsation = pulsation;
+
+            this.detection = detection;
+        }
+
+        /// <inheritdoc/>
+        public bool Detect(TSignal signal)
+        {
+            var pulse = pulsation.Pulsate(signal);
+
+            return detection.Detect(pulse);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseOfSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseOfSpecification.cs
@@ -1,0 +1,88 @@
+﻿using NUnit.Framework;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(WhenPulseOf<>))]
+    internal class WhenPulseOfSpecification :
+        IPulsation<Signal>
+    {
+        private Pulse expected;
+
+        public Pulse Pulsate(Signal signal)
+        {
+            if (signal == null)
+            {
+                throw new ArgumentNullException(nameof(signal));
+            }
+
+            return expected;
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseIsDisabled()
+        {
+            expected = Pulse.IsDisabled;
+
+            Assert.IsTrue(WhenPulseOf<Signal>.IsDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.IsEnabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasEnabled(this).Detect(new Signal()));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseHasDisabled()
+        {
+            expected = Pulse.HasDisabled;
+
+            Assert.IsFalse(WhenPulseOf<Signal>.IsDisabled(this).Detect(new Signal()));
+            Assert.IsTrue(WhenPulseOf<Signal>.HasDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.IsEnabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasEnabled(this).Detect(new Signal()));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseIsEnabled()
+        {
+            expected = Pulse.IsEnabled;
+
+            Assert.IsFalse(WhenPulseOf<Signal>.IsDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasDisabled(this).Detect(new Signal()));
+            Assert.IsTrue(WhenPulseOf<Signal>.IsEnabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasEnabled(this).Detect(new Signal()));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseHasEnabled()
+        {
+            expected = Pulse.HasEnabled;
+
+            Assert.IsFalse(WhenPulseOf<Signal>.IsDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.HasDisabled(this).Detect(new Signal()));
+            Assert.IsFalse(WhenPulseOf<Signal>.IsEnabled(this).Detect(new Signal()));
+            Assert.IsTrue(WhenPulseOf<Signal>.HasEnabled(this).Detect(new Signal()));
+        }
+
+        [Test]
+        public void CannotBeGeneratetdWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var detection = WhenPulseOf<Signal>.IsDisabled(null);
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var detection = WhenPulseOf<Signal>.HasDisabled(null);
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var detection = WhenPulseOf<Signal>.IsEnabled(null);
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var detection = WhenPulseOf<Signal>.HasEnabled(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Detection/WhenPulseSpecification.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(WhenPulse))]
+    internal class WhenPulseSpecification
+    {
+        [Test]
+        public void ShouldDetectWhenPulseIsDisabled()
+        {
+            Assert.IsTrue(WhenPulse.IsDisabled.Detect(Pulse.IsDisabled));
+            Assert.IsFalse(WhenPulse.IsDisabled.Detect(Pulse.HasDisabled));
+            Assert.IsFalse(WhenPulse.IsDisabled.Detect(Pulse.IsEnabled));
+            Assert.IsFalse(WhenPulse.IsDisabled.Detect(Pulse.HasEnabled));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseHasDisabled()
+        {
+            Assert.IsFalse(WhenPulse.HasDisabled.Detect(Pulse.IsDisabled));
+            Assert.IsTrue(WhenPulse.HasDisabled.Detect(Pulse.HasDisabled));
+            Assert.IsFalse(WhenPulse.HasDisabled.Detect(Pulse.IsEnabled));
+            Assert.IsFalse(WhenPulse.HasDisabled.Detect(Pulse.HasEnabled));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseIsEnabled()
+        {
+            Assert.IsFalse(WhenPulse.IsEnabled.Detect(Pulse.IsDisabled));
+            Assert.IsFalse(WhenPulse.IsEnabled.Detect(Pulse.HasDisabled));
+            Assert.IsTrue(WhenPulse.IsEnabled.Detect(Pulse.IsEnabled));
+            Assert.IsFalse(WhenPulse.IsEnabled.Detect(Pulse.HasEnabled));
+        }
+
+        [Test]
+        public void ShouldDetectWhenPulseHasEnabled()
+        {
+            Assert.IsFalse(WhenPulse.HasEnabled.Detect(Pulse.IsDisabled));
+            Assert.IsFalse(WhenPulse.HasEnabled.Detect(Pulse.HasDisabled));
+            Assert.IsFalse(WhenPulse.HasEnabled.Detect(Pulse.IsEnabled));
+            Assert.IsTrue(WhenPulse.HasEnabled.Detect(Pulse.HasEnabled));
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/InputSignal.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/InputSignal.cs
@@ -1,0 +1,10 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    internal sealed class InputSignal :
+        ISignal
+    {
+
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/OutputSignal.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/OutputSignal.cs
@@ -1,0 +1,10 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    internal sealed class OutputSignal :
+        ISignal
+    {
+
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/IPulsation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/IPulsation.cs
@@ -1,0 +1,25 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Converts <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to convert.
+    /// </typeparam>
+    public interface IPulsation<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Converts <typeparamref name="TSignal"/> to <see cref="Pulse"/>.
+        /// </summary>
+        /// <param name="signal">
+        /// <typeparamref name="TSignal"/> to convert.
+        /// </param>
+        /// <returns>
+        /// <see cref="Pulse"/> converted.
+        /// </returns>
+        Pulse Pulsate(TSignal signal);
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulsate.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulsate.cs
@@ -1,0 +1,21 @@
+﻿using YggdrAshill.Nuadha.Signalization.Experimental;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    internal sealed class Pulsate<TSignal> :
+        IConversion<TSignal, Pulse>
+        where TSignal : ISignal
+    {
+        private readonly IPulsation<TSignal> pulsation;
+
+        internal Pulsate(IPulsation<TSignal> pulsation)
+        {
+            this.pulsation = pulsation;
+        }
+
+        public Pulse Convert(TSignal signal)
+        {
+            return pulsation.Pulsate(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulsation.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulsation.cs
@@ -1,0 +1,77 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="IPulsation{TSignal}"/>.
+    /// </summary>
+    /// <typeparam name="TSignal">
+    /// Type of <see cref="ISignal"/> to pulsate.
+    /// </typeparam>
+    public sealed class Pulsation<TSignal> :
+        IPulsation<TSignal>
+        where TSignal : ISignal
+    {
+        /// <summary>
+        /// Always converts <typeparamref name="TSignal"/> to <see cref="Pulse.IsDisabled"/>.
+        /// </summary>
+        public static Pulsation<TSignal> IsDisabled { get; }
+            = new Pulsation<TSignal>(_ =>
+            {
+                return Pulse.IsDisabled;
+            });
+        /// <summary>
+        /// Always converts <typeparamref name="TSignal"/> to <see cref="Pulse.HasDisabled"/>.
+        /// </summary>
+        public static Pulsation<TSignal> HasDisabled { get; }
+            = new Pulsation<TSignal>(_ =>
+            {
+                return Pulse.HasDisabled;
+            });
+        /// <summary>
+        /// Always converts <typeparamref name="TSignal"/> to <see cref="Pulse.IsEnabled"/>.
+        /// </summary>
+        public static Pulsation<TSignal> IsEnabled { get; }
+            = new Pulsation<TSignal>(_ =>
+            {
+                return Pulse.IsEnabled;
+            });
+        /// <summary>
+        /// Always converts <typeparamref name="TSignal"/> to <see cref="Pulse.HasEnabled"/>.
+        /// </summary>
+        public static Pulsation<TSignal> HasEnabled { get; }
+            = new Pulsation<TSignal>(_ =>
+            {
+                return Pulse.HasEnabled;
+            });
+
+        private readonly Func<TSignal, Pulse> onPulsated;
+
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        /// <param name="onPulsated">
+        /// <see cref="Func{TSignal, Pulse}"/> to execute when this has pulsated.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="onPulsated"/> is null.
+        /// </exception>
+        public Pulsation(Func<TSignal, Pulse> onPulsated)
+        {
+            if (onPulsated == null)
+            {
+                throw new ArgumentNullException(nameof(onPulsated));
+            }
+
+            this.onPulsated = onPulsated;
+        }
+
+        /// <inheritdoc/>
+        public Pulse Pulsate(TSignal signal)
+        {
+            return onPulsated.Invoke(signal);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulsationSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulsationSpecification.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Pulsation<>))]
+    internal class PulsationSpecification
+    {
+        private static object[] Pulses =>
+            new object[]
+            {
+                Pulse.IsDisabled,
+                Pulse.HasDisabled,
+                Pulse.IsEnabled,
+                Pulse.HasEnabled,
+            };
+
+        [TestCaseSource(nameof(Pulses))]
+        public void ShouldExecuteFunctionWhenHasPulsated(Pulse expected)
+        {
+            var pulsation = new Pulsation<Signal>(signal =>
+            {
+                if (signal == null)
+                {
+                    throw new ArgumentNullException(nameof(signal));
+                }
+
+                return expected;
+            });
+
+            var pulsated = pulsation.Pulsate(new Signal());
+
+            Assert.AreEqual(expected, pulsated);
+        }
+
+        [Test]
+        public void CannotBeGeneratedWithNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var pulsation = new Pulsation<Signal>(null);
+            });
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulse.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/Pulse.cs
@@ -1,0 +1,114 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    /// <summary>
+    /// Implementation of <see cref="ISignal"/>.
+    /// </summary>
+    public sealed class Pulse :
+        ISignal,
+        IEquatable<Pulse>
+    {
+        private enum State
+        {
+            IsDisabled,
+            HasDisabled,
+            IsEnabled,
+            HasEnabled,
+        }
+
+        private readonly State state;
+
+        private Pulse(State state)
+        {
+            this.state = state;
+        }
+
+        /// <summary>
+        /// <see cref="Pulse"/> that is disabled.
+        /// </summary>
+        public static Pulse IsDisabled { get; } = new Pulse(State.IsDisabled);
+        /// <summary>
+        /// <see cref="Pulse"/> that has disabled.
+        /// </summary>
+        public static Pulse HasDisabled { get; } = new Pulse(State.HasDisabled);
+        /// <summary>
+        /// <see cref="Pulse"/> that is enabled.
+        /// </summary>
+        public static Pulse IsEnabled { get; } = new Pulse(State.IsEnabled);
+        /// <summary>
+        /// <see cref="Pulse"/> that has enabled.
+        /// </summary>
+        public static Pulse HasEnabled { get; } = new Pulse(State.HasEnabled);
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{state}";
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return (int)state;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+            {
+                return false;
+            }
+
+            if (obj is Pulse pulse)
+            {
+                return Equals(pulse);
+            }
+
+            return false;
+        }
+        /// <inheritdoc/>
+        public bool Equals(Pulse other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return state.Equals(other.state);
+        }
+
+        /// <summary>
+        /// Checks if <see cref="Pulse"/> and <see cref="Pulse"/> are equal.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator ==(Pulse left, Pulse right)
+        {
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(right, null);
+            }
+
+            if (ReferenceEquals(right, null))
+            {
+                return false;
+            }
+
+            return left.Equals(right);
+        }
+        /// <summary>
+        /// Checks if <see cref="Pulse"/> and <see cref="Pulse"/> are not equal.
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator !=(Pulse left, Pulse right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulseSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulseSpecification.cs
@@ -1,0 +1,54 @@
+﻿using NUnit.Framework;
+using YggdrAshill.Nuadha.Transformation.Experimental;
+
+namespace YggdrAshill.Nuadha.Experimental.Specification
+{
+    [TestFixture(TestOf = typeof(Pulse))]
+    internal class PulseSpecification
+    {
+        [Test]
+        public void ShouldBeEqualWhenPulseIsDisabled()
+        {
+            Assert.IsTrue(Pulse.IsDisabled == Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.IsDisabled != Pulse.HasDisabled);
+            Assert.IsTrue(Pulse.IsDisabled != Pulse.IsEnabled);
+            Assert.IsTrue(Pulse.IsDisabled != Pulse.HasEnabled);
+        }
+
+        [Test]
+        public void ShouldBeEqualWhenPulseHasDisabled()
+        {
+            Assert.IsTrue(Pulse.HasDisabled == Pulse.HasDisabled);
+            Assert.IsTrue(Pulse.HasDisabled != Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.HasDisabled != Pulse.IsEnabled);
+            Assert.IsTrue(Pulse.HasDisabled != Pulse.HasEnabled);
+        }
+
+        [Test]
+        public void ShouldBeEqualWhenPulseIsEnabled()
+        {
+            Assert.IsTrue(Pulse.IsEnabled == Pulse.IsEnabled);
+            Assert.IsTrue(Pulse.IsEnabled != Pulse.HasDisabled);
+            Assert.IsTrue(Pulse.IsEnabled != Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.IsEnabled != Pulse.HasEnabled);
+        }
+
+        [Test]
+        public void ShouldBeEqualWhenPulseHasEnabled()
+        {
+            Assert.IsTrue(Pulse.HasEnabled == Pulse.HasEnabled);
+            Assert.IsTrue(Pulse.HasEnabled != Pulse.HasDisabled);
+            Assert.IsTrue(Pulse.HasEnabled != Pulse.IsEnabled);
+            Assert.IsTrue(Pulse.HasEnabled != Pulse.IsDisabled);
+        }
+
+        [Test]
+        public void CannotBeEqualToNull()
+        {
+            Assert.IsTrue(Pulse.IsDisabled != null);
+            Assert.IsTrue(Pulse.HasDisabled != null);
+            Assert.IsTrue(Pulse.IsEnabled != null);
+            Assert.IsTrue(Pulse.HasEnabled != null);
+        }
+    }
+}

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulseSpecification.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/Pulsation/PulseSpecification.cs
@@ -18,8 +18,8 @@ namespace YggdrAshill.Nuadha.Experimental.Specification
         [Test]
         public void ShouldBeEqualWhenPulseHasDisabled()
         {
-            Assert.IsTrue(Pulse.HasDisabled == Pulse.HasDisabled);
             Assert.IsTrue(Pulse.HasDisabled != Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.HasDisabled == Pulse.HasDisabled);
             Assert.IsTrue(Pulse.HasDisabled != Pulse.IsEnabled);
             Assert.IsTrue(Pulse.HasDisabled != Pulse.HasEnabled);
         }
@@ -27,19 +27,19 @@ namespace YggdrAshill.Nuadha.Experimental.Specification
         [Test]
         public void ShouldBeEqualWhenPulseIsEnabled()
         {
-            Assert.IsTrue(Pulse.IsEnabled == Pulse.IsEnabled);
-            Assert.IsTrue(Pulse.IsEnabled != Pulse.HasDisabled);
             Assert.IsTrue(Pulse.IsEnabled != Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.IsEnabled != Pulse.HasDisabled);
+            Assert.IsTrue(Pulse.IsEnabled == Pulse.IsEnabled);
             Assert.IsTrue(Pulse.IsEnabled != Pulse.HasEnabled);
         }
 
         [Test]
         public void ShouldBeEqualWhenPulseHasEnabled()
         {
-            Assert.IsTrue(Pulse.HasEnabled == Pulse.HasEnabled);
+            Assert.IsTrue(Pulse.HasEnabled != Pulse.IsDisabled);
             Assert.IsTrue(Pulse.HasEnabled != Pulse.HasDisabled);
             Assert.IsTrue(Pulse.HasEnabled != Pulse.IsEnabled);
-            Assert.IsTrue(Pulse.HasEnabled != Pulse.IsDisabled);
+            Assert.IsTrue(Pulse.HasEnabled == Pulse.HasEnabled);
         }
 
         [Test]

--- a/YggdrAshill.Nuadha.Specification/Experimental/Transformation/TransformationExtension.cs
+++ b/YggdrAshill.Nuadha.Specification/Experimental/Transformation/TransformationExtension.cs
@@ -1,0 +1,69 @@
+using YggdrAshill.Nuadha.Signalization.Experimental;
+using System;
+
+namespace YggdrAshill.Nuadha.Transformation.Experimental
+{
+    public static class TransformationExtension
+    {
+        public static IProduction<TOutput> Convert<TInput, TOutput>(this IProduction<TInput> production, IConversion<TInput, TOutput> conversion)
+            where TInput : ISignal
+            where TOutput : ISignal
+        {
+            if (production == null)
+            {
+                throw new ArgumentNullException(nameof(production));
+            }
+            if (conversion == null)
+            {
+                throw new ArgumentNullException(nameof(conversion));
+            }
+
+            return new Converter<TInput, TOutput>(production, conversion);
+        }
+
+        public static IProduction<TSignal> Convert<TSignal>(this IProduction<TSignal> production, ICorrection<TSignal> correction)
+            where TSignal : ISignal
+        {
+            if (production == null)
+            {
+                throw new ArgumentNullException(nameof(production));
+            }
+            if (correction == null)
+            {
+                throw new ArgumentNullException(nameof(correction));
+            }
+
+            return production.Convert(new Correct<TSignal>(correction));
+        }
+
+        public static IProduction<Pulse> Convert<TSignal>(this IProduction<TSignal> production, IPulsation<TSignal> pulsation)
+            where TSignal : ISignal
+        {
+            if (production == null)
+            {
+                throw new ArgumentNullException(nameof(production));
+            }
+            if (pulsation == null)
+            {
+                throw new ArgumentNullException(nameof(pulsation));
+            }
+
+            return production.Convert(new Pulsate<TSignal>(pulsation));
+        }
+
+        public static IProduction<Notice> Detect<TSignal>(this IProduction<TSignal> production, IDetection<TSignal> detection)
+            where TSignal : ISignal
+        {
+            if (production == null)
+            {
+                throw new ArgumentNullException(nameof(production));
+            }
+            if (detection == null)
+            {
+                throw new ArgumentNullException(nameof(detection));
+            }
+
+            return new Detector<TSignal>(production, detection);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Defined how to 

- convert
- correct
- pulsate
- detect

signals.

## Done

This pull request defined

- interfaces
- implementations
- specifications

for Transformation.

## Undone

Transformation module is replacement for Conversion module, but this pull request didn't replace it.
Therefore, the namespace of new definitions for Transformation has "Experimental".

## Influence

This pull request doesn't influence this framework.
But, Conversion module needs to be replaced with Transformation eventually.

## Concerns

Nothing because this pull request was created by repository owner.

## Additional context (Optional)

Nothing.
